### PR TITLE
Replace outdated m2r dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
-    'm2r'
+    'm2r2'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
-m2r
+m2r2
 numpy
 transforms3d
+sphinx-rtd-theme


### PR DESCRIPTION
Hi, I tried generating the docs locally but with a recent Python version (3.10), m2r is not working anymore. I got this error:
```
Could not import extension m2r (exception: cannot import name 'ErrorString' from 'docutils.core'
(/Users/martin/git/spherov2.py/docs/venv/lib/python3.10/site-packages/docutils/core.py))
```

That's a known issue with m2r, see for example [here](https://bugs.archlinux.org/task/75433) and [here](https://github.com/miyakogi/m2r/pull/67).

Since m2r is not maintained anymore, [m2r2](https://pypi.org/project/m2r2) was created which I'm proposing to use in this PR.

I tested the change locally and was able to generate the docs.