### PR TITLE
Enable finding SPRK+ and implement reset_heading for older toys

### DIFF
--- a/spherov2/controls/v1.py
+++ b/spherov2/controls/v1.py
@@ -175,6 +175,11 @@ class DriveControl:
 
     def set_raw_motors(self, left_mode, left_speed, right_mode, right_speed):
         self.__toy.set_raw_motors(left_mode, left_speed, right_mode, right_speed)
+        
+    def reset_heading(self):
+        self.set_stabilization(False)
+        self.__toy.set_heading(0)
+        self.set_stabilization(True)
 
 
 class FirmwareUpdateControl:

--- a/spherov2/scanner.py
+++ b/spherov2/scanner.py
@@ -12,6 +12,7 @@ from spherov2.toy.ollie import Ollie
 from spherov2.toy.r2d2 import R2D2
 from spherov2.toy.r2q5 import R2Q5
 from spherov2.toy.rvr import RVR
+from spherov2.toy.sprk2 import Sprk2
 
 
 class ToyNotFoundError(Exception):
@@ -94,3 +95,4 @@ find_R2D2: Callable[..., R2D2] = partial(find_toy, toy_types=[R2D2])
 find_R2Q5: Callable[..., R2Q5] = partial(find_toy, toy_types=[R2Q5])
 find_RVR: Callable[..., RVR] = partial(find_toy, toy_types=[RVR])
 find_BOLT: Callable[..., BOLT] = partial(find_toy, toy_types=[BOLT])
+find_Sprk2: Callable[..., Sprk2] = partial(find_toy, toy_types=[Sprk2])


### PR DESCRIPTION
Hi, I would like to propose two updates to the library.

#### 1) Fix for finding SPRK+ toys.
The scanner filters out any non-Sphero Bluetooth device by recursively checking if it belongs to any of the toy classes and their subclasses. However, `__subclasses__` only returns the already imported classes. Since the line `from spherov2.toy.sprk2 import Sprk2` was missing, the scanner would always filter out SPRK+ toys and return an empty list.

#### 2) Add missing API for resetting the heading
Edu API has a method for resetting the toy's heading. In the ToyUtil, this method only checks if the toy implements `drive_control`. Older (V1) toys do have the `drive_control` but it does not implement `reset_heading` which results in an ugly error. 
Since this is a very useful function, I have decided to implement it by disabling the stabilization, setting the heading to zero (the toy doesn't move because stabilization is disabled), and then reenabling the stabilization. I tested this on Sphero SPRK+ and it works great, but unfortunately, I don't have other toys to confirm.

I am happy to hear your comments and suggestions.